### PR TITLE
Sync env setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Code Interpreter 환경에서는 가상환경 없이 바로 사용할 수 있습
 
 # 자동 검증 항목:
 # ✅ 환경변수 설정 상태 (7개)
-# ✅ 라이브러리 설치 상태 (13개) 
+# ✅ 라이브러리 설치 상태 (13개)
 # ✅ 백엔드 모듈 임포트 (7개)
 # ✅ 클라이언트 연결 테스트
 ```
@@ -71,6 +71,8 @@ cd backend && ./activate.sh
 
 # 필요한 패키지 설치
 pip install -r backend/requirements.txt
+# 환경변수 파일 자동 생성
+./setup_agent_env.sh
 
 # 서버 실행
 cd backend && python main.py
@@ -78,6 +80,9 @@ cd backend && python main.py
 # 가상환경 비활성화
 deactivate
 ```
+
+`setup_agent_env.sh` 스크립트는 `backend/.env`가 없을 경우
+`backend/.env.example`을 복사해 자동으로 생성합니다.
 
 #### Docker 환경 사용
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,19 @@
+# Freshdesk Configuration
+FRESHDESK_DOMAIN=your-domain.freshdesk.com
+FRESHDESK_API_KEY=your-freshdesk-api-key
+
+# Qdrant Cloud Configuration
+QDRANT_URL=https://your-cluster.cloud.qdrant.io
+QDRANT_API_KEY=your-qdrant-api-key
+
+# LLM API Keys
+ANTHROPIC_API_KEY=your-anthropic-api-key
+OPENAI_API_KEY=your-openai-api-key
+GOOGLE_API_KEY=your-google-api-key
+
+# Application Settings
+COMPANY_ID=wedosoft
+PROCESS_ATTACHMENTS=true
+EMBEDDING_MODEL=text-embedding-3-small
+LOG_LEVEL=INFO
+MAX_TOKENS=4096

--- a/setup_agent_env.sh
+++ b/setup_agent_env.sh
@@ -37,37 +37,13 @@ echo -e "${GREEN}의존성 설치 완료.${NC}"
 # .env 파일 설정
 echo -e "\n${YELLOW}4. .env 파일 설정 중...${NC}"
 if [ ! -f "backend/.env" ]; then
-    echo -e "${YELLOW}backend/.env 파일이 없습니다. 기본 설정으로 생성합니다.${NC}"
-    # config.py를 참고하여 필수 환경변수 설정
-    cat > backend/.env << EOL
-FRESHDESK_API_KEY=your_freshdesk_api_key
-# FRESHDESK_DOMAIN: 도메인 이름만 입력 (예: "your-company") 또는 전체 도메인 (예: "your-company.freshdesk.com")
-# 시스템에서 자동으로 company_id를 추출하여 X-Company-ID 헤더에 사용합니다
-FRESHDESK_DOMAIN=your_freshdesk_domain
-
-# =================================================================
-# Qdrant Cloud 벡터 데이터베이스 설정
-# =================================================================
-QDRANT_URL=https://your-qdrant-url
-QDRANT_API_KEY=your_qdrant_api_key
-
-# =================================================================
-# LLM API 키 설정 (Multi-LLM Router용)
-# =================================================================
-ANTHROPIC_API_KEY=your_anthropic_api_key
-OPENAI_API_KEY=your_openai_api_key
-GOOGLE_API_KEY=your_google_api_key
-
-# =================================================================
-# 애플리케이션 설정
-# =================================================================
-COMPANY_ID=your_company_id
-PROCESS_ATTACHMENTS=true
-EMBEDDING_MODEL=text-embedding-3-small
-LOG_LEVEL=INFO
-MAX_TOKENS=4096
-EOL
-    echo -e "${GREEN}backend/.env 파일 생성 완료. 파일을 열어 API 키 등 필수 정보를 입력해주세요.${NC}"
+    echo -e "${YELLOW}backend/.env 파일이 없습니다. 템플릿에서 복사합니다.${NC}"
+    if [ -f "backend/.env.example" ]; then
+        cp backend/.env.example backend/.env
+        echo -e "${GREEN}backend/.env 파일이 backend/.env.example에서 생성되었습니다.${NC}"
+    else
+        echo -e "${YELLOW}backend/.env.example 파일을 찾을 수 없습니다. 수동으로 생성해주세요.${NC}"
+    fi
 else
     echo -e "${GREEN}backend/.env 파일이 이미 존재합니다.${NC}"
 fi

--- a/setup_agent_env.sh
+++ b/setup_agent_env.sh
@@ -40,6 +40,10 @@ if [ ! -f "backend/.env" ]; then
     echo -e "${YELLOW}backend/.env 파일이 없습니다. 템플릿에서 복사합니다.${NC}"
     if [ -f "backend/.env.example" ]; then
         cp backend/.env.example backend/.env
+        if [ $? -ne 0 ]; then
+            echo -e "${YELLOW}backend/.env 파일 복사에 실패했습니다. 수동으로 생성해주세요.${NC}"
+            exit 1
+        fi
         echo -e "${GREEN}backend/.env 파일이 backend/.env.example에서 생성되었습니다.${NC}"
     else
         echo -e "${YELLOW}backend/.env.example 파일을 찾을 수 없습니다. 수동으로 생성해주세요.${NC}"


### PR DESCRIPTION
## Summary
- duplicate `.env.example` under backend
- build backend `.env` from template in `setup_agent_env.sh`
- document automatic env file creation in README

## Testing
- `pre-commit run --files setup_agent_env.sh README.md backend/.env.example`
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'core' and qdrant_client.errors due to missing services)*

------
https://chatgpt.com/codex/tasks/task_e_6848475938088320b0e607d6be39d81d